### PR TITLE
Add getCategoryById and getCategoryByName API at CategoryController

### DIFF
--- a/src/main/java/com/glowmart/shop_management/controller/CategoryController.java
+++ b/src/main/java/com/glowmart/shop_management/controller/CategoryController.java
@@ -2,6 +2,7 @@ package com.glowmart.shop_management.controller;
 
 import com.glowmart.shop_management.api.CategoryAPI;
 import com.glowmart.shop_management.dto.CategoryDto;
+import com.glowmart.shop_management.exception.NotFoundException;
 import com.glowmart.shop_management.service.CategoryService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -48,6 +49,28 @@ public class CategoryController {
     public ResponseEntity<List<CategoryDto>> getAllCategory(){
         List<CategoryDto> allCategory = categoryService.getAllCategory();
         return ResponseEntity.ok(allCategory);
+    }
+
+    @GetMapping(CategoryAPI.CATEGORY_BY_ID)
+    public ResponseEntity<?> getCategoryById(@RequestParam("id") Long id){
+        try {
+            CategoryDto categoryById =categoryService.getCategoryById(id);
+            return ResponseEntity.ok(categoryById);
+        } catch (Exception e) {
+            e.printStackTrace();
+            return new ResponseEntity<>(e.getMessage(), HttpStatus.NOT_FOUND);
+        }
+    }
+
+    @GetMapping(CategoryAPI.CATEGORY_BY_NAME)
+    public ResponseEntity<?> getCategoryByName(@RequestParam("name") String name){
+        try {
+            CategoryDto categoryByName = categoryService.getCategoryByName(name);
+            return ResponseEntity.ok(categoryByName);
+        } catch (Exception e) {
+            e.printStackTrace();
+            return new ResponseEntity<>(e.getMessage(), HttpStatus.NOT_FOUND);
+        }
     }
 
 }

--- a/src/main/java/com/glowmart/shop_management/repository/CategoryRepository.java
+++ b/src/main/java/com/glowmart/shop_management/repository/CategoryRepository.java
@@ -6,10 +6,14 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface CategoryRepository extends JpaRepository<Category, Long> {
 
     @Query("SELECT CASE WHEN COUNT(c) > 0 THEN true ELSE false END FROM Category c WHERE c.categoryName = :categoryName")
     boolean existsCategoryByName(@Param("categoryName") String categoryName);
 
+    @Query("SELECT c FROM Category c WHERE c.categoryName = :categoryName")
+    Optional<Category> getCategoryByName(String categoryName);
 }

--- a/src/main/java/com/glowmart/shop_management/security/SecurityConfig.java
+++ b/src/main/java/com/glowmart/shop_management/security/SecurityConfig.java
@@ -43,7 +43,9 @@ public class SecurityConfig {
                                 CategoryAPI.BASE_PATH + CategoryAPI.CATEGORY_LIST).permitAll()
                         .requestMatchers(CategoryAPI.BASE_PATH + CategoryAPI.CATEGORY_CREATE,
                                 CategoryAPI.BASE_PATH + CategoryAPI.CATEGORY_UPDATE,
-                                CategoryAPI.BASE_PATH + CategoryAPI.CATEGORY_DELETE).hasRole("ADMIN")
+                                CategoryAPI.BASE_PATH + CategoryAPI.CATEGORY_DELETE,
+                                CategoryAPI.BASE_PATH + CategoryAPI.CATEGORY_BY_ID,
+                                CategoryAPI.BASE_PATH + CategoryAPI.CATEGORY_BY_NAME).hasRole("ADMIN")
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/glowmart/shop_management/service/CategoryService.java
+++ b/src/main/java/com/glowmart/shop_management/service/CategoryService.java
@@ -13,4 +13,8 @@ public interface CategoryService {
     CategoryDto deleteCategoryById(Long id);
 
     List<CategoryDto> getAllCategory();
+
+    CategoryDto getCategoryById(Long id);
+
+    CategoryDto getCategoryByName(String name);
 }

--- a/src/main/java/com/glowmart/shop_management/service/implementation/CategoryServiceImpl.java
+++ b/src/main/java/com/glowmart/shop_management/service/implementation/CategoryServiceImpl.java
@@ -35,11 +35,11 @@ public class CategoryServiceImpl implements CategoryService {
 
     @Override
     public CategoryDto updateCategoryById(Long id, CategoryDto categoryDto) {
-        Optional<Category> findCategoryById = categoryRepository.findById(id);
-        if(findCategoryById.isEmpty()){
+        Optional<Category> categoryById = categoryRepository.findById(id);
+        if(categoryById.isEmpty()){
             throw new NotFoundException("There is no category by id:" + id + "!");
         }
-        Category updateCategoryById = findCategoryById.get();
+        Category updateCategoryById = categoryById.get();
         updateCategoryById.setCategoryName(categoryDto.getCategoryName());
         updateCategoryById.setUpdatedAt(LocalDateTime.now());
         return CategoryConverter.convertToCategoryDto(categoryRepository.save(updateCategoryById));
@@ -47,8 +47,8 @@ public class CategoryServiceImpl implements CategoryService {
 
     @Override
     public CategoryDto deleteCategoryById(Long id) {
-        Optional<Category> findCategoryById = categoryRepository.findById(id);
-        if(findCategoryById.isEmpty()){
+        Optional<Category> categoryById = categoryRepository.findById(id);
+        if(categoryById.isEmpty()){
             throw new NotFoundException("There is no category by id:" + id + "!");
         }
         try {
@@ -57,13 +57,27 @@ public class CategoryServiceImpl implements CategoryService {
             //return new ResponseEntity<>(exception.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
             System.out.println(exception.getMessage() + "==>" + HttpStatus.INTERNAL_SERVER_ERROR);
         }
-        return CategoryConverter.convertToCategoryDto(findCategoryById.get());
+        return CategoryConverter.convertToCategoryDto(categoryById.get());
     }
 
     @Override
     public List<CategoryDto> getAllCategory() {
         List<Category> allCategory = categoryRepository.findAll();
         return allCategory.stream().map(CategoryConverter::convertToCategoryDto).collect(Collectors.toList());
+    }
+
+    @Override
+    public CategoryDto getCategoryById(Long id) {
+        return categoryRepository.findById(id)
+                .map(CategoryConverter::convertToCategoryDto)
+                .orElseThrow(() -> new NotFoundException("There is no category by id:" + id + "!"));
+    }
+
+    @Override
+    public CategoryDto getCategoryByName(String name) {
+        return categoryRepository.getCategoryByName(name)
+                .map(CategoryConverter::convertToCategoryDto)
+                .orElseThrow(() -> new NotFoundException("There is no category by name:" + name + "!"));
     }
 
 }


### PR DESCRIPTION
### Feature: Get Category by ID and Name
**What’s Added**

> Implemented getCategoryById(Long id) and getCategoryByName(String name) endpoints in CategoryController.
> Enhanced exception handling for missing categories with user-friendly 404 responses.
> Updated service layer to support these operations with null-checks and custom exceptions.

**How to Test**

> GET http://localhost:8081/api/category/get-by-id?id=1 — should return category with ID 1.
> GET http://localhost:8081/api/category/get-by-name?name=Laptop — should return category laptop.
> GET http://localhost:8081/api/category/get-by-name?name=Train— should return 404 with message:

**Notes**

> Includes exception handling via GlobalExceptionHandler.
> SecurityConfig restricts access to users with ROLE_ADMIN.

**Checklist**

> Code compiles and passes existing tests
> New endpoints return proper response codes
> Manual test cases have been verified in Postman