### PR TITLE
Fix bug to create and search category by lower case letter of category name.

### DIFF
--- a/src/main/java/com/glowmart/shop_management/controller/CategoryController.java
+++ b/src/main/java/com/glowmart/shop_management/controller/CategoryController.java
@@ -22,20 +22,20 @@ public class CategoryController {
     public ResponseEntity<?> createCategory(@RequestBody CategoryDto categoryDto){
         try{
             CategoryDto createdCategoryDto = categoryService.createCategory(categoryDto);
-        } catch (Exception exception){
-            return new ResponseEntity<>(exception, HttpStatus.BAD_REQUEST);
+            return new ResponseEntity<>("Category is successfully created.", HttpStatus.CREATED);
+        } catch (Exception e){
+            return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
         }
-        return new ResponseEntity<>("Category is successfully created.", HttpStatus.CREATED);
     }
 
     @PutMapping(CategoryAPI.CATEGORY_UPDATE)
     public ResponseEntity<?> updateCategoryById(@PathVariable("id") Long id, @RequestBody CategoryDto categoryDto){
         try{
             CategoryDto updateCategoryById = categoryService.updateCategoryById(id, categoryDto);
+            return new ResponseEntity<>("Category is successfully updated.", HttpStatus.OK);
         } catch(Exception exception) {
-            return new ResponseEntity<>(exception.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+            return new ResponseEntity<>(exception.getMessage(), HttpStatus.NOT_FOUND);
         }
-        return new ResponseEntity<>("Category is successfully updated.", HttpStatus.OK);
     }
 
     @DeleteMapping(CategoryAPI.CATEGORY_DELETE)

--- a/src/main/java/com/glowmart/shop_management/service/implementation/CategoryServiceImpl.java
+++ b/src/main/java/com/glowmart/shop_management/service/implementation/CategoryServiceImpl.java
@@ -25,6 +25,7 @@ public class CategoryServiceImpl implements CategoryService {
 
     @Override
     public CategoryDto createCategory(CategoryDto categoryDto) {
+        categoryDto.setCategoryName(categoryDto.getCategoryName().toLowerCase());
         if(categoryRepository.existsCategoryByName(categoryDto.getCategoryName())){
             throw new DuplicateCategoryException(categoryDto.getCategoryName() + " is already exists!");
         }
@@ -75,9 +76,10 @@ public class CategoryServiceImpl implements CategoryService {
 
     @Override
     public CategoryDto getCategoryByName(String name) {
-        return categoryRepository.getCategoryByName(name)
+        String categoryName = name.toLowerCase();
+        return categoryRepository.getCategoryByName(categoryName)
                 .map(CategoryConverter::convertToCategoryDto)
-                .orElseThrow(() -> new NotFoundException("There is no category by name:" + name + "!"));
+                .orElseThrow(() -> new NotFoundException("There is no category by name:" + categoryName + "!"));
     }
 
 }


### PR DESCRIPTION
### Bug Fix: Create and Search Category by Lowercase Name
**Description**

> This PR fixes a bug where category creation and search were case-sensitive, causing inconsistent behavior. Now, category names are consistently stored and searched in lowercase.

**Changes**

> Converted category name to lowercase during creation.
> Updated search functionality to compare category names in lowercase.

**Impact**

> Prevents duplicate categories with same name but different cases (e.g., "Books" vs "books").
> Ensures search results are case-insensitive and consistent.

**Test**

- Created categories with mixed-case names.
- Searched using different letter cases — results return correctly.
- Verified no duplicate categories are created based on case.